### PR TITLE
Optimize Collision Performance

### DIFF
--- a/flyer/Game/Catchme.cs
+++ b/flyer/Game/Catchme.cs
@@ -84,7 +84,7 @@ namespace flyer.Game
             var x = catcher.x - catchee.x;
             var y = catcher.y - catchee.y;
             var z = catcher.z - catchee.z;
-            return Math.Sqrt(x * x + y * y + z * z) < 1;
+            return (x * x + y * y + z * z) < 1;
         }
 
         public Guid? GetCatcher()


### PR DESCRIPTION
wenn man sich die wurzel spart bei der kollisionsberechnung, und dafür das abstandsquadrat als bedingung nimmt, gewinnt man performance